### PR TITLE
Improve bot workflows and add database tests

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,29 +1,49 @@
+from __future__ import annotations
+
 import asyncio
-import json
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
+from typing import Dict, List, Optional, Tuple
+
 from aiogram import Bot, Dispatcher, types
 from aiogram.filters import Command
+from aiogram.types import BufferedInputFile, ReplyKeyboardMarkup, ReplyKeyboardRemove
 from openai import AsyncOpenAI
-from config import BOT_TOKEN, GPT_API_KEY, GPT_ASSISTANT_ID, ADMIN_ID
-from utils.vpn import add_vpn_user
-from utils.qrgen import make_qr
+
+from config import ADMIN_ID, BOT_TOKEN, GPT_API_KEY, GPT_ASSISTANT_ID
 from utils.db import (
-    init_db, save_message, get_last_messages,
-    save_vpn_key, get_expiring_keys, renew_vpn_key,
-    get_expired_keys, deactivate_vpn_key, get_all_active_users
+    get_all_active_users,
+    get_expired_keys,
+    get_expiring_keys,
+    get_last_messages,
+    init_db,
+    renew_vpn_key,
+    save_message,
+    save_vpn_key,
 )
-import subprocess
-import os
+from utils.qrgen import make_qr
+from utils.vpn import add_vpn_user
+
+
+if not BOT_TOKEN:
+    raise RuntimeError("BOT_TOKEN environment variable is not configured")
 
 bot = Bot(token=BOT_TOKEN)
 dp = Dispatcher()
-client = AsyncOpenAI(api_key=GPT_API_KEY)
-XRAY_CONFIG = "/usr/local/etc/xray/config.json"
+client = AsyncOpenAI(api_key=GPT_API_KEY) if GPT_API_KEY else None
+
+
+DEFAULT_SUBSCRIPTION_DAYS = 30
+EXPIRING_THRESHOLD_DAYS = 3
+BROADCAST_TIMEOUT = timedelta(minutes=10)
+
+
+pending_broadcast: Dict[int, datetime] = {}
+notified_expiring: set[Tuple[int, datetime]] = set()
 
 
 # === Проверка прав ===
-def is_admin(user_id):
-    return user_id == ADMIN_ID
+def is_admin(user_id: int) -> bool:
+    return ADMIN_ID is not None and user_id == ADMIN_ID
 
 
 # === Команда /start ===
@@ -46,7 +66,7 @@ async def admin_panel(msg: types.Message):
     if not is_admin(msg.from_user.id):
         return await msg.answer("⛔ Доступ запрещён")
 
-    keyboard = types.ReplyKeyboardMarkup(resize_keyboard=True)
+    keyboard = ReplyKeyboardMarkup(resize_keyboard=True)
     keyboard.add("/users", "/expired")
     keyboard.add("/broadcast")
     await msg.answer("⚙️ Панель администратора:", reply_markup=keyboard)
@@ -61,11 +81,13 @@ async def list_users(msg: types.Message):
     users = get_all_active_users()
     if not users:
         return await msg.answer("👤 Активных пользователей нет.")
-    
+
     text = "👥 Активные пользователи:\n\n"
     for u in users:
         uid, name, exp = u
-        text += f"• {name} — до {exp[:10]} (ID: {uid})\n"
+        display_name = name or str(uid)
+        display_date = exp[:10] if isinstance(exp, str) else exp
+        text += f"• {display_name} — до {display_date} (ID: {uid})\n"
     await msg.answer(text)
 
 
@@ -78,10 +100,10 @@ async def expired_users(msg: types.Message):
     expired = get_expired_keys()
     if not expired:
         return await msg.answer("✅ Нет просроченных подключений.")
-    
+
     text = "🚫 Просроченные пользователи:\n\n"
     for user_id, full_name, _ in expired:
-        text += f"• {full_name} (ID: {user_id})\n"
+        text += f"• {full_name or user_id} (ID: {user_id})\n"
     await msg.answer(text)
 
 
@@ -91,34 +113,240 @@ async def broadcast(msg: types.Message):
     if not is_admin(msg.from_user.id):
         return await msg.answer("⛔ Доступ запрещён")
 
-    await msg.answer("📢 Введите текст рассылки:")
-    dp.message.register(send_broadcast)
+    pending_broadcast[msg.from_user.id] = datetime.now(UTC)
+    await msg.answer(
+        "📢 Введите текст рассылки."
+        "\nОтправьте /cancel для отмены.",
+        reply_markup=ReplyKeyboardRemove(),
+    )
 
 
-async def send_broadcast(msg: types.Message):
-    if not is_admin(msg.from_user.id):
-        return
+def _format_name(message: types.Message) -> str:
+    user = message.from_user
+    if not user:
+        return "Неизвестный пользователь"
+    if user.full_name:
+        return user.full_name
+    if user.username:
+        return f"@{user.username}"
+    return str(user.id)
+
+
+def _default_user_keyboard() -> ReplyKeyboardRemove:
+    return ReplyKeyboardRemove()
+
+
+async def _send_qr(message: types.Message, link: str, expires_at: datetime) -> None:
+    qr = make_qr(link)
+    photo = BufferedInputFile(qr.getvalue(), filename="vpn_qr.png")
+    expires_text = expires_at.strftime("%d.%m.%Y")
+    caption = (
+        "✅ Подключение готово!\n\n"
+        f"📅 Доступ активен до {expires_text}.\n"
+        "📱 Отсканируйте QR-код или используйте ссылку ниже."
+    )
+    await message.answer_photo(photo, caption=caption)
+    await message.answer(link)
+
+
+async def _handle_broadcast_text(message: types.Message) -> bool:
+    admin_id = message.from_user.id if message.from_user else None
+    if not admin_id or admin_id not in pending_broadcast:
+        return False
+
+    started_at = pending_broadcast.pop(admin_id)
+    if not message.text:
+        pending_broadcast[admin_id] = datetime.now(UTC)
+        await message.answer(
+            "Можно отправлять только текстовые сообщения для рассылки.",
+            reply_markup=_default_user_keyboard(),
+        )
+        return True
+    if message.text == "/cancel":
+        await message.answer("🚫 Рассылка отменена.", reply_markup=_default_user_keyboard())
+        return True
+
+    if datetime.now(UTC) - started_at > BROADCAST_TIMEOUT:
+        await message.answer(
+            "⌛ Время ожидания истекло. Отправьте /broadcast, чтобы начать заново.",
+            reply_markup=_default_user_keyboard(),
+        )
+        return True
 
     users = get_all_active_users()
-    text = msg.text
-    count = 0
-    for u in users:
+    sent = 0
+    for user_id, *_ in users:
         try:
-            await bot.send_message(u[0], text)
-            count += 1
+            await bot.send_message(user_id, message.text)
+            sent += 1
             await asyncio.sleep(0.2)
-        except:
-            pass
-    await msg.answer(f"✅ Сообщение отправлено {count} пользователям.")
-    dp.message.unregister(send_broadcast)
+        except Exception:
+            continue
+
+    await message.answer(
+        f"✅ Сообщение отправлено {sent} пользователям.",
+        reply_markup=_default_user_keyboard(),
+    )
+    return True
 
 
-# === Остальные функции (buy, renew, GPT, мониторинг) — остаются без изменений ===
-# ... (вставь сюда код с предыдущей версии bot.py)
+async def _generate_ai_reply(message: types.Message) -> str:
+    if not message.text:
+        return "Я могу отвечать только на текстовые сообщения."
+
+    history = get_last_messages(message.from_user.id, limit=5)
+    model = GPT_ASSISTANT_ID or "gpt-4o-mini"
+
+    prompt_messages = [
+        {
+            "role": "system",
+            "content": (
+                "Ты — AI-помощник сервиса VPN GPT. Помоги пользователю подобрать VPN,"
+                " объясни преимущества, помоги с настройкой и сопровождением."
+            ),
+        }
+    ]
+    for previous_message, previous_reply in history:
+        prompt_messages.append({"role": "user", "content": previous_message})
+        prompt_messages.append({"role": "assistant", "content": previous_reply})
+    prompt_messages.append({"role": "user", "content": message.text})
+
+    if not client:
+        return (
+            "Сейчас сервис консультанта недоступен."
+            " Попробуйте снова позже или используйте команду /buy для покупки VPN."
+        )
+
+    try:
+        response = await client.chat.completions.create(
+            model=model,
+            messages=prompt_messages,
+            temperature=0.7,
+        )
+    except Exception:
+        return (
+            "Произошла ошибка при обращении к модели."
+            " Попробуйте повторить запрос чуть позже."
+        )
+
+    choices = getattr(response, "choices", None)
+    if not choices:
+        return "Я не получил ответа от модели. Попробуйте ещё раз."
+
+    reply = choices[0].message.content if choices[0].message else None
+    if not reply:
+        return "Ответ модели пуст. Попробуйте переформулировать вопрос."
+    return reply.strip()
+
+
+async def _notify_expiring_users() -> None:
+    if not ADMIN_ID:
+        return
+
+    while True:
+        await asyncio.sleep(3600)
+        expiring = get_expiring_keys(EXPIRING_THRESHOLD_DAYS)
+        fresh: List[str] = []
+        for user_id, name, expires_at in expiring:
+            key = (user_id, expires_at)
+            if key in notified_expiring:
+                continue
+            notified_expiring.add(key)
+            formatted_name = name or str(user_id)
+            fresh.append(
+                f"• {formatted_name} — истекает {expires_at.strftime('%d.%m.%Y')}"
+            )
+
+        if fresh:
+            text = "⏰ Подписки на исходе:\n" + "\n".join(fresh)
+            try:
+                await bot.send_message(ADMIN_ID, text)
+            except Exception:
+                pass
+
+
+async def _handle_buy(message: types.Message) -> None:
+    expires_at = datetime.now(UTC) + timedelta(days=DEFAULT_SUBSCRIPTION_DAYS)
+    link = add_vpn_user()
+    save_vpn_key(
+        message.from_user.id,
+        message.from_user.username if message.from_user else None,
+        _format_name(message),
+        link,
+        expires_at,
+    )
+    await message.answer("⏳ Создаю подключение...")
+    await _send_qr(message, link, expires_at)
+    _log_interaction(
+        message,
+        "Выдано новое VPN-подключение. Ссылка: {link}. Доступ до {date}.".format(
+            link=link, date=expires_at.strftime("%d.%m.%Y")
+        ),
+    )
+
+
+async def _handle_renew(message: types.Message) -> None:
+    new_expiration = renew_vpn_key(message.from_user.id, DEFAULT_SUBSCRIPTION_DAYS)
+    if not new_expiration:
+        await message.answer(
+            "ℹ️ Активных подключений не найдено. Используйте команду /buy для покупки VPN.",
+        )
+        return
+    reply = (
+        "🔄 Подписка продлена!\n"
+        f"Новый срок действия до {new_expiration.strftime('%d.%m.%Y')}."
+    )
+    await message.answer(reply)
+    _log_interaction(message, reply)
+
+
+def _log_interaction(message: types.Message, reply: str) -> None:
+    save_message(
+        message.from_user.id,
+        message.from_user.username if message.from_user else None,
+        _format_name(message),
+        message.text or "",
+        reply,
+    )
+
+
+@dp.message(Command("buy"))
+async def buy(message: types.Message) -> None:
+    await _handle_buy(message)
+
+
+@dp.message(Command("renew"))
+async def renew(message: types.Message) -> None:
+    await _handle_renew(message)
+
+
+@dp.message(Command("cancel"))
+async def cancel(message: types.Message) -> None:
+    if await _handle_broadcast_text(message):
+        return
+    await message.answer(
+        "Нет активных действий для отмены.", reply_markup=_default_user_keyboard()
+    )
+
+
+@dp.message()
+async def handle_message(message: types.Message) -> None:
+    if await _handle_broadcast_text(message):
+        return
+    if not message.text:
+        await message.answer(
+            "Я могу обработать только текст. Попробуйте описать ваш вопрос словами."
+        )
+        return
+
+    reply = await _generate_ai_reply(message)
+    await message.answer(reply)
+    _log_interaction(message, reply)
 
 
 async def main():
     init_db()
+    asyncio.create_task(_notify_expiring_users())
     await dp.start_polling(bot)
 
 

--- a/config.py
+++ b/config.py
@@ -1,9 +1,39 @@
+from __future__ import annotations
 import os
-from dotenv import load_dotenv
+from typing import Callable, Optional, TypeVar
+
+try:
+    from dotenv import load_dotenv  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    def load_dotenv(*_args, **_kwargs):  # type: ignore
+        return False
+
+
 load_dotenv()
 
-BOT_TOKEN = os.getenv("BOT_TOKEN")
-GPT_API_KEY = os.getenv("GPT_API_KEY")
-GPT_ASSISTANT_ID = os.getenv("GPT_ASSISTANT_ID")
-ADMIN_ID = int(os.getenv("ADMIN_ID"))
+T = TypeVar("T")
+
+
+def _read_env(
+    name: str,
+    *,
+    cast: Optional[Callable[[str], T]] = None,
+    default: Optional[T] = None,
+) -> Optional[T]:
+    value = os.getenv(name)
+    if value is None or value == "":
+        return default
+    if cast is None:
+        return value  # type: ignore[return-value]
+    try:
+        return cast(value)
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError(f"Environment variable {name} has invalid value") from exc
+
+
+BOT_TOKEN = _read_env("BOT_TOKEN")
+GPT_API_KEY = _read_env("GPT_API_KEY")
+GPT_ASSISTANT_ID = _read_env("GPT_ASSISTANT_ID")
+ADMIN_ID = _read_env("ADMIN_ID", cast=int)
+
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def reload_config(monkeypatch, **env):
+    for key in ("BOT_TOKEN", "GPT_API_KEY", "GPT_ASSISTANT_ID", "ADMIN_ID"):
+        monkeypatch.delenv(key, raising=False)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+
+    if "config" in sys.modules:
+        del sys.modules["config"]
+    return importlib.import_module("config")
+
+
+def test_admin_id_cast(monkeypatch):
+    module = reload_config(monkeypatch, ADMIN_ID="101")
+    assert module.ADMIN_ID == 101
+
+
+def test_admin_id_invalid_value(monkeypatch):
+    with pytest.raises(RuntimeError):
+        reload_config(monkeypatch, ADMIN_ID="not-an-int")
+
+
+def test_optional_values_default_to_none(monkeypatch):
+    module = reload_config(monkeypatch)
+    assert module.BOT_TOKEN is None
+    assert module.GPT_API_KEY is None
+    assert module.GPT_ASSISTANT_ID is None
+    assert module.ADMIN_ID is None

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import sqlite3
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from utils import db
+
+
+@pytest.fixture()
+def isolated_db(tmp_path, monkeypatch):
+    database_path = tmp_path / "test.db"
+    monkeypatch.setattr(db, "DB_PATH", str(database_path))
+    db.init_db()
+    return database_path
+
+
+def test_save_and_get_last_messages(isolated_db):
+    user_id = 123
+    db.save_message(user_id, "user", "Test User", "Hello", "Hi there")
+    db.save_message(user_id, "user", "Test User", "How are you?", "Great!")
+
+    history = db.get_last_messages(user_id, limit=5)
+
+    assert history == [
+        ("Hello", "Hi there"),
+        ("How are you?", "Great!"),
+    ]
+
+
+def test_vpn_key_lifecycle(isolated_db):
+    user_id = 77
+    expires_at = datetime.now(UTC) + timedelta(days=2)
+    key_uuid = db.save_vpn_key(user_id, "vpn_user", "VPN User", "vless://example", expires_at)
+
+    assert isinstance(key_uuid, str)
+    assert len(key_uuid) > 0
+
+    active_users = db.get_all_active_users()
+    assert active_users == [(user_id, "VPN User", expires_at.isoformat())]
+
+    renewed = db.renew_vpn_key(user_id, extend_days=5)
+    assert renewed is not None
+    assert renewed > expires_at
+
+    soon_expiring = db.get_expiring_keys(days_before=10)
+    assert (user_id, "VPN User", renewed) in soon_expiring
+
+    # Force expiration
+    expired_at = datetime.now(UTC) - timedelta(days=1)
+    with sqlite3.connect(db.DB_PATH) as conn:
+        conn.execute("UPDATE vpn_keys SET expires_at = ? WHERE user_id = ?", (expired_at.isoformat(), user_id))
+        conn.commit()
+
+    expired = db.get_expired_keys()
+    assert expired == [(user_id, "VPN User", "vless://example")]
+
+    db.deactivate_vpn_key(user_id)
+    assert db.get_all_active_users() == []

--- a/utils/db.py
+++ b/utils/db.py
@@ -1,155 +1,210 @@
+from __future__ import annotations
+
 import sqlite3
-from datetime import datetime, timedelta
-
-DB_PATH = "/root/VPN_GPT/dialogs.db"
-
-
-def init_db():
-    conn = sqlite3.connect(DB_PATH)
-    c = conn.cursor()
-
-    c.execute("""
-        CREATE TABLE IF NOT EXISTS history (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            user_id INTEGER,
-            username TEXT,
-            full_name TEXT,
-            message TEXT,
-            reply TEXT,
-            created_at TEXT
-        )
-    """)
-
-    c.execute("""
-        CREATE TABLE IF NOT EXISTS vpn_keys (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            user_id INTEGER,
-            username TEXT,
-            full_name TEXT,
-            key_uuid TEXT,
-            link TEXT,
-            issued_at TEXT,
-            expires_at TEXT,
-            active INTEGER DEFAULT 1
-        )
-    """)
-
-    conn.commit()
-    conn.close()
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import List, Optional, Tuple
 
 
-def save_message(user_id, username, full_name, message, reply):
+DB_PATH = str(Path(__file__).resolve().parents[1] / "dialogs.db")
+
+
+def _ensure_db_directory() -> None:
+    Path(DB_PATH).parent.mkdir(parents=True, exist_ok=True)
+
+
+def init_db() -> None:
+    _ensure_db_directory()
     with sqlite3.connect(DB_PATH) as conn:
         c = conn.cursor()
+
         c.execute("""
-            INSERT INTO history (user_id, username, full_name, message, reply, created_at)
-            VALUES (?, ?, ?, ?, ?, ?)
-        """, (user_id, username, full_name, message, reply, datetime.utcnow().isoformat()))
+            CREATE TABLE IF NOT EXISTS history (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id INTEGER,
+                username TEXT,
+                full_name TEXT,
+                message TEXT,
+                reply TEXT,
+                created_at TEXT
+            )
+        """)
+
+        c.execute("""
+            CREATE TABLE IF NOT EXISTS vpn_keys (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id INTEGER,
+                username TEXT,
+                full_name TEXT,
+                key_uuid TEXT,
+                link TEXT,
+                issued_at TEXT,
+                expires_at TEXT,
+                active INTEGER DEFAULT 1
+            )
+        """)
+
         conn.commit()
 
 
-def get_last_messages(user_id, limit=5):
-    conn = sqlite3.connect(DB_PATH)
-    c = conn.cursor()
-    c.execute("""
-        SELECT message, reply FROM history
-        WHERE user_id = ?
-        ORDER BY id DESC
-        LIMIT ?
-    """, (user_id, limit))
-    rows = c.fetchall()
-    conn.close()
-    return rows[::-1]
+def save_message(
+    user_id: int,
+    username: Optional[str],
+    full_name: Optional[str],
+    message: str,
+    reply: str,
+) -> None:
+    with sqlite3.connect(DB_PATH) as conn:
+        c = conn.cursor()
+        c.execute(
+            """
+            INSERT INTO history (user_id, username, full_name, message, reply, created_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                user_id,
+                username,
+                full_name,
+                message,
+                reply,
+                datetime.now(UTC).isoformat(),
+            ),
+        )
+        conn.commit()
 
 
-def save_vpn_key(user_id, username, full_name, link, expires_at):
+def get_last_messages(user_id: int, limit: int = 5) -> List[Tuple[str, str]]:
+    with sqlite3.connect(DB_PATH) as conn:
+        c = conn.cursor()
+        c.execute(
+            """
+            SELECT message, reply FROM history
+            WHERE user_id = ?
+            ORDER BY id DESC
+            LIMIT ?
+            """,
+            (user_id, limit),
+        )
+        rows = c.fetchall()
+    return list(reversed(rows))
+
+
+def save_vpn_key(
+    user_id: int,
+    username: Optional[str],
+    full_name: Optional[str],
+    link: str,
+    expires_at: datetime,
+) -> str:
     import uuid
+
     key_uuid = str(uuid.uuid4())
     with sqlite3.connect(DB_PATH) as conn:
         c = conn.cursor()
-        c.execute("""
+        c.execute(
+            """
             INSERT INTO vpn_keys (user_id, username, full_name, key_uuid, link, issued_at, expires_at)
             VALUES (?, ?, ?, ?, ?, ?, ?)
-        """, (user_id, username, full_name, key_uuid, link, datetime.utcnow().isoformat(), expires_at.isoformat()))
+            """,
+            (
+                user_id,
+                username,
+                full_name,
+                key_uuid,
+                link,
+                datetime.now(UTC).isoformat(),
+                expires_at.isoformat(),
+            ),
+        )
         conn.commit()
+    return key_uuid
 
 
-def get_expiring_keys(days_before=3):
-    conn = sqlite3.connect(DB_PATH)
-    c = conn.cursor()
-    threshold = (datetime.utcnow() + timedelta(days=days_before)).isoformat()
-    c.execute("""
-        SELECT user_id, full_name, expires_at FROM vpn_keys
-        WHERE active = 1 AND expires_at <= ?
-    """, (threshold,))
-    rows = c.fetchall()
-    conn.close()
+def get_expiring_keys(days_before: int = 3) -> List[Tuple[int, Optional[str], datetime]]:
+    threshold = (datetime.now(UTC) + timedelta(days=days_before)).isoformat()
+    with sqlite3.connect(DB_PATH) as conn:
+        c = conn.cursor()
+        c.execute(
+            """
+            SELECT user_id, full_name, expires_at FROM vpn_keys
+            WHERE active = 1 AND expires_at <= ?
+            """,
+            (threshold,),
+        )
+        rows = c.fetchall()
 
-    parsed = []
+    parsed: List[Tuple[int, Optional[str], datetime]] = []
     for user_id, name, exp in rows:
         try:
             parsed.append((user_id, name, datetime.fromisoformat(exp)))
-        except:
+        except ValueError:
             continue
     return parsed
 
 
-def renew_vpn_key(user_id, extend_days=30):
-    conn = sqlite3.connect(DB_PATH)
-    c = conn.cursor()
-    c.execute("""
-        SELECT id, expires_at FROM vpn_keys
-        WHERE user_id = ? AND active = 1
-        ORDER BY id DESC LIMIT 1
-    """, (user_id,))
-    row = c.fetchone()
+def renew_vpn_key(user_id: int, extend_days: int = 30) -> Optional[datetime]:
+    with sqlite3.connect(DB_PATH) as conn:
+        c = conn.cursor()
+        c.execute(
+            """
+            SELECT id, expires_at FROM vpn_keys
+            WHERE user_id = ? AND active = 1
+            ORDER BY id DESC LIMIT 1
+            """,
+            (user_id,),
+        )
+        row = c.fetchone()
 
-    if not row:
-        conn.close()
-        return None
+        if not row:
+            return None
 
-    key_id, old_exp = row
-    old_exp_date = datetime.fromisoformat(old_exp)
-    new_exp_date = old_exp_date + timedelta(days=extend_days)
+        key_id, old_exp = row
+        old_exp_date = datetime.fromisoformat(old_exp)
+        new_exp_date = old_exp_date + timedelta(days=extend_days)
 
-    c.execute("UPDATE vpn_keys SET expires_at = ? WHERE id = ?", (new_exp_date.isoformat(), key_id))
-    conn.commit()
-    conn.close()
-    return new_exp_date
+        c.execute(
+            "UPDATE vpn_keys SET expires_at = ? WHERE id = ?",
+            (new_exp_date.isoformat(), key_id),
+        )
+        conn.commit()
+        return new_exp_date
 
 
-def get_expired_keys():
-    conn = sqlite3.connect(DB_PATH)
-    c = conn.cursor()
-    now = datetime.utcnow().isoformat()
-    c.execute("""
-        SELECT user_id, full_name, link
-        FROM vpn_keys
-        WHERE active = 1 AND expires_at < ?
-        ORDER BY expires_at ASC
-    """, (now,))
-    rows = c.fetchall()
-    conn.close()
+def get_expired_keys() -> List[Tuple[int, Optional[str], str]]:
+    now = datetime.now(UTC).isoformat()
+    with sqlite3.connect(DB_PATH) as conn:
+        c = conn.cursor()
+        c.execute(
+            """
+            SELECT user_id, full_name, link
+            FROM vpn_keys
+            WHERE active = 1 AND expires_at < ?
+            ORDER BY expires_at ASC
+            """,
+            (now,),
+        )
+        rows = c.fetchall()
     return rows
 
 
-def deactivate_vpn_key(user_id):
+def deactivate_vpn_key(user_id: int) -> None:
     with sqlite3.connect(DB_PATH) as conn:
         c = conn.cursor()
         c.execute("UPDATE vpn_keys SET active = 0 WHERE user_id = ?", (user_id,))
         conn.commit()
 
 
-def get_all_active_users():
-    conn = sqlite3.connect(DB_PATH)
-    c = conn.cursor()
-    c.execute("""
-        SELECT user_id, full_name, expires_at
-        FROM vpn_keys
-        WHERE active = 1
-        ORDER BY expires_at DESC
-    """)
-    rows = c.fetchall()
-    conn.close()
+def get_all_active_users() -> List[Tuple[int, Optional[str], str]]:
+    with sqlite3.connect(DB_PATH) as conn:
+        c = conn.cursor()
+        c.execute(
+            """
+            SELECT user_id, full_name, expires_at
+            FROM vpn_keys
+            WHERE active = 1
+            ORDER BY expires_at DESC
+            """
+        )
+        rows = c.fetchall()
     return rows
 


### PR DESCRIPTION
## Summary
- refactor the Telegram bot to add broadcast handling, GPT chat responses, VPN provisioning, and admin monitoring utilities
- harden configuration loading and database helpers with timezone-safe timestamps
- add unit tests for configuration parsing and SQLite persistence

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68e21c400f5c83269f45aef9b0b3cc58