### PR TITLE
Load VLESS host from project env file

### DIFF
--- a/api/endpoints/morune.py
+++ b/api/endpoints/morune.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, Header, HTTPException
 from pydantic import BaseModel
 
 from ..utils import db, xray
+from ..utils.env import get_vless_host
 
 router = APIRouter()
 
@@ -32,7 +33,7 @@ def process_payment(payload: PaymentIn, x_admin_token: str | None = Header(defau
     uuid = new_client["uuid"]
     issued = datetime.utcnow()
     expires = issued + timedelta(days=payload.days)
-    vless_host = os.getenv("VLESS_HOST", "YOUR_HOST")
+    vless_host = get_vless_host()
     vless_port = os.getenv("VLESS_PORT", "2053")
     link = f"vless://{uuid}@{vless_host}:{vless_port}?encryption=none#VPN_GPT"
 

--- a/api/endpoints/vpn.py
+++ b/api/endpoints/vpn.py
@@ -11,12 +11,13 @@ from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 
 from ..utils import xray
+from ..utils.env import get_vless_host
 from ..utils.db import connect
 
 
 router = APIRouter()
 
-HOST = os.getenv("VLESS_HOST", "vpn-gpt.store")
+HOST = get_vless_host()
 PORT = os.getenv("VLESS_PORT", "2053")
 
 

--- a/api/utils/env.py
+++ b/api/utils/env.py
@@ -1,0 +1,106 @@
+"""Utilities for reading configuration from environment files."""
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from pathlib import Path
+from typing import Iterable, Iterator
+
+from dotenv import dotenv_values
+
+
+def _candidate_keys() -> Iterable[str]:
+    """Return the environment keys that may contain the VLESS host."""
+
+    # Order matters: prefer the explicit key first and fall back to common
+    # alternatives that may exist in legacy deployments.
+    return ("VLESS_HOST", "VLESS_DOMAIN", "DOMAIN", "DOMAIN_NAME", "HOST")
+
+
+def _normalise_host(value: str | None) -> str | None:
+    """Clean up host values and drop placeholders.
+
+    The production `.env` keeps only the bare domain name. Nevertheless, we
+    guard against accidental schemes, trailing slashes, or placeholders used in
+    development to ensure a consistent result.
+    """
+
+    if not value:
+        return None
+
+    candidate = value.strip()
+    if not candidate:
+        return None
+
+    # Drop URL schemes if somebody provided `https://example.com`.
+    if "://" in candidate:
+        candidate = candidate.split("://", 1)[1]
+
+    candidate = candidate.strip("/")
+    if not candidate:
+        return None
+
+    # Ignore obvious placeholders left from local development configs.
+    placeholders = {"your_host", "example.com", "localhost"}
+    if candidate.lower() in placeholders:
+        return None
+
+    return candidate
+
+
+def _iter_env_files() -> Iterator[Path]:
+    """Yield probable `.env` files ordered by proximity to the project."""
+
+    seen: set[Path] = set()
+
+    def walk(start: Path) -> Iterator[Path]:
+        cursor = start if start.is_dir() else start.parent
+
+        while True:
+            env_path = cursor / ".env"
+            if env_path not in seen:
+                seen.add(env_path)
+                if env_path.exists():
+                    yield env_path
+
+            if cursor.parent == cursor:
+                break
+            cursor = cursor.parent
+
+    module_root = Path(__file__).resolve().parent
+    cwd_root = Path.cwd()
+
+    for candidate in (module_root, cwd_root):
+        yield from walk(candidate)
+
+    project_root = os.getenv("PROJECT_ROOT")
+    if project_root:
+        yield from walk(Path(project_root).expanduser().resolve())
+
+
+@lru_cache(maxsize=1)
+def get_vless_host(default: str = "vpn-gpt.store") -> str:
+    """Return the VLESS host using environment configuration.
+
+    The production server keeps the domain in the project root `.env`. When the
+    environment variable is missing (for example after deployments), we read
+    the file directly so that freshly issued VLESS links contain the real
+    domain instead of a placeholder.
+    """
+
+    host = _normalise_host(os.getenv("VLESS_HOST"))
+    if host:
+        return host
+
+    for env_path in _iter_env_files():
+        values = dotenv_values(env_path)
+        for key in _candidate_keys():
+            host = _normalise_host(values.get(key))
+            if host:
+                return host
+
+    return default
+
+
+__all__ = ["get_vless_host"]
+


### PR DESCRIPTION
## Summary
- add an env utility that loads the VLESS host from the project root .env file or known environment keys
- use the shared helper in the VPN issue and Morune endpoints so generated links pick up the configured domain
- expand the env helper to walk likely project roots for the `.env` file so deployments always resolve the configured host

## Testing
- python -m compileall api

------
https://chatgpt.com/codex/tasks/task_e_68e5ba9ac2a0832698872775c7e60759