### PR TITLE
Update VPN domain references

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Telegram бот ↔ Custom GPT ↔ VPN API / Xray
    uvicorn api.main:app --host 0.0.0.0 --port 8000
    ```
 
-   При использовании доменного имени укажите его в `OPENAPI_SERVER_URL=https://example.com` — так панель будет формировать корректные ссылки на API.
+   При использовании доменного имени укажите его в `OPENAPI_SERVER_URL=https://vpn-gpt.store` — так панель будет формировать корректные ссылки на API.
 3. **Проксируйте трафик через HTTPS.** Настройте Nginx/Caddy/Traefik и пробросьте `/admin/ui` и `/admin/*` к backend-сервису, добавив, при необходимости, дополнительную HTTP Basic Auth.
 4. **Ограничьте доступ при работе без прокси.** Для точечного доступа достаточно SSH-туннеля: `ssh -L 8080:127.0.0.1:8000 user@server` и затем откройте `http://localhost:8080/admin/ui` в браузере.
 

--- a/api/utils/env.py
+++ b/api/utils/env.py
@@ -56,7 +56,7 @@ def _normalise_host(value: str | None) -> str | None:
     if not candidate:
         return None
 
-    # Drop URL schemes if somebody provided `https://example.com`.
+    # Drop URL schemes if somebody provided `https://vpn-gpt.store`.
     if "://" in candidate:
         candidate = candidate.split("://", 1)[1]
 

--- a/tests/test_bot_markup.py
+++ b/tests/test_bot_markup.py
@@ -31,7 +31,7 @@ _build_invoice_markup = stars_module._build_invoice_markup
 
 
 def test_is_supported_button_link_accepts_http_and_https():
-    assert _is_supported_button_link("https://example.com")
+    assert _is_supported_button_link("https://vpn-gpt.store")
     assert _is_supported_button_link("http://example.com/path")
 
 

--- a/tests/test_content_filters.py
+++ b/tests/test_content_filters.py
@@ -54,7 +54,7 @@ def test_send_message_applies_sanitizer(monkeypatch):
             return DummyResponse()
 
     monkeypatch.setattr(telegram, "BOT_TOKEN", "token")
-    monkeypatch.setattr(telegram, "BASE", "https://example.com")
+    monkeypatch.setattr(telegram, "BASE", "https://vpn-gpt.store")
     monkeypatch.setattr(telegram.httpx, "AsyncClient", lambda timeout=30: DummyClient())
 
     asyncio.run(telegram.send_message(123, "гео блокировка снята"))

--- a/tests/test_vpn_api.py
+++ b/tests/test_vpn_api.py
@@ -409,7 +409,7 @@ def test_auto_update_adds_trial_column(tmp_path):
                 "legacy",
                 123,
                 "uuid-legacy",
-                "https://example.com",
+                "https://vpn-gpt.store",
                 "Legacy",
                 "US",
                 "2024-01-01T00:00:00",


### PR DESCRIPTION
## Summary
- replace legacy https://example.com links with https://vpn-gpt.store across tests and documentation
- align environment helper comment with the production domain

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f7b4ff94fc83269d7f7192cafa7c61